### PR TITLE
Better error handling

### DIFF
--- a/src/event/error.js
+++ b/src/event/error.js
@@ -1,0 +1,15 @@
+// Errors from command execution
+
+module.exports = (client, error, message) => {
+    if(!error) return
+
+    if(error instanceof Error) {
+        if (error.stack.includes('Missing Permissions')) {
+            return client.logger.error('Permission Error')
+        } else {
+            return client.logger.error(error.stack, message)
+        }
+    }
+
+    return client.logger.error(error)
+}

--- a/src/event/messageCreate.js
+++ b/src/event/messageCreate.js
@@ -41,9 +41,5 @@ module.exports = async (client, message) => {
     }
 
     //LOADING COMMANDS
-    try {
-        cmd.run(client, message, args);
-    } catch (e) {
-        client.emit("error", e, message);
-    }
+    cmd.run(client, message, args).catch(err => client.emit("error", err, message))
 };

--- a/src/utils/handlers/error.js
+++ b/src/utils/handlers/error.js
@@ -1,15 +1,17 @@
 module.exports = async (client) => {
 
     process.on('unhandledRejection', err => {
-        if(err) {
+        if(!err) return
+            
+        if(err instanceof Error) {
             if (err.stack.includes('An invalid token was provided.')) {
                 return client.logger.error('Bad token see config.js for set the token')
-            } else if (err.stack.includes('Missing Permissions')) {
-                return client.logger.error('Permission Error')
             } else {
                 return client.logger.error(err.stack)
             }
         }
+    
+        client.logger.error(err)
     });
    
     process.on('uncaughtException', err =>{


### PR DESCRIPTION
At `./src/event/messageCreate.js` line 44, I was found that you are using try-catch to handle exceptions thrown asynchronously. 

At `./src/event/messageCreate.js` line 47, you emitted an error event, but you didn't listen to it.

At `./src/utils/handlers/error.js`, the `unhandledRejection` part, `err` is not always an instance of `Error`.

I did not make too much changes as I want to maintain the current structure as much as I can. I hope this is helpful :P 