### PR TITLE
Update slash.js

### DIFF
--- a/slash.js
+++ b/slash.js
@@ -1,32 +1,34 @@
-// This file allows you to register slash commands, it must be launched each time you add a new (/) command
-
-const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v9');
-const { readdirSync } = require('fs');
-const path = require('path');
+const { REST } = require("@discordjs/rest");
+const { Routes } = require("discord-api-types/v9");
+const { readdirSync } = require("fs");
+const path = require("path");
 const config = require("./config");
 
-const commands = []
-readdirSync("./src/slashCommands/").map(async dir => {
-	readdirSync(`./src/slashCommands/${dir}/`).map(async (cmd) => {
-	commands.push(require(path.join(__dirname, `./src/slashCommands/${dir}/${cmd}`)))
-    })
-})
+const commands = [];
+readdirSync("./src/slashCommands/").map(async (dir) => {
+  readdirSync(`./src/slashCommands/${dir}/`).map(async (cmd) => {
+    commands.push(
+      require(path.join(__dirname, `./src/slashCommands/${dir}/${cmd}`))
+    );
+  });
+});
 const rest = new REST({ version: "9" }).setToken(config.token);
 
 (async () => {
-	try {
-		console.log('[Discord API] Started refreshing application (/) commands.');
-		await rest.put(
-            // GUILD SLASH COMMANDS (will deploy only in the server you put the ID of)
-			// Routes.applicationGuildCommands(config.botID, 'ID_OF_THE_GUILD'),
+  try {
+    console.log("[Discord API] Started refreshing application (/) commands.");
+    await rest.put(
+      // GUILD SLASH COMMANDS (will deploy only in the server you put the ID of)
+      Routes.applicationGuildCommands(config.botID, 'ID_OF_THE_GUILD'),
 
-            // GLOBAL SLASH COMMANDS
-			Routes.applicationCommands(config.botID),
-			{ body: commands },
-		);
-		console.log('[Discord API] Successfully reloaded application (/) commands.');
-	} catch (error) {
-		console.error(error);
-	}
+      // GLOBAL SLASH COMMANDS
+      //Routes.applicationCommands(config.botID),
+      { body: commands }
+    );
+    console.log(
+      "[Discord API] Successfully reloaded application (/) commands."
+    );
+  } catch (error) {
+    console.error(error);
+  }
 })();


### PR DESCRIPTION
Patch of the slash.js file to remove the Discord API error.

```
Started refreshing application (/) commands.
w[0]: 401: Unauthorized
    at Z.runRequest (C:\Users\utilisateur\Desktop\Veloxy v.0.1\node_modules\@discordjs\rest\dist\index.js:7:581)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Z.queueRequest (C:\Users\utilisateur\Desktop\Veloxy v.0.1\node_modules\@discordjs\rest\dist\index.js:5:2989)
    at async C:\Users\utilisateur\Desktop\Veloxy v.0.1\slash.js:20:5 {
  rawError: { message: '401: Unauthorized', code: 0 },
  code: 0,
  status: 401,
  method: 'put',
  url: 'https://discord.com/api/v9/applications/1040769310131503255/guilds/1040770536478875678/commands',
  requestBody: { attachments: undefined, json: [ [Object] ] }
}
```